### PR TITLE
I2c allow error

### DIFF
--- a/tmx_pico_aio/private_constants.py
+++ b/tmx_pico_aio/private_constants.py
@@ -52,7 +52,8 @@ class PrivateConstants:
     SPI_READ_BLOCKING = 26
     SPI_SET_FORMAT = 27
     SPI_CS_CONTROL = 28
-
+    SET_SCAN_DELAY = 29
+    ENCODER_NEW = 30
 
     # reports
     # debug data from Arduino
@@ -67,7 +68,7 @@ class PrivateConstants:
     SONAR_DISTANCE = 11
     DHT_REPORT = 12
     SPI_REPORT = 13
-
+    ENCODER_REPORT = 14
     DEBUG_PRINT = 99
 
     TELEMETRIX_VERSION = "1.3"
@@ -78,9 +79,6 @@ class PrivateConstants:
     REPORTING_DIGITAL_ENABLE = 2
     REPORTING_ANALOG_DISABLE = 3
     REPORTING_DIGITAL_DISABLE = 4
-
-    # length of report pico ID message
-    REPORT_PICO_ID_MESSAGE_LENGTH = 10
 
     # Pin mode definitions
 
@@ -96,7 +94,7 @@ class PrivateConstants:
     AT_I2C = 9
     AT_NEO_PIXEL = 10
     AT_SPI = 11
-
+    AT_ENCODER = 12
     AT_MODE_NOT_SET = 255
 
     # flag to indicate that an i2c command does not specify a register
@@ -123,6 +121,8 @@ class PrivateConstants:
 
     # maximum number of DHT devices allowed
     MAX_DHTS = 2
+
+    MAX_ENCODERS = 4
 
     # DHT Report sub-types
     DHT_DATA = 0

--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -1117,7 +1117,7 @@ class TmxPicoAio:
         # use a raw pwm write from the calculated values
         await self.pwm_write(pin_number, duty_cycle, True)
 
-    def set_pin_mode_encoder(self, pin_A, pin_B=0, callback=None,quadrature = True):
+    async def set_pin_mode_encoder(self, pin_A, pin_B=0, callback=None,quadrature = True):
         """
         :param pin_A:  Sensor trigger gpio pin
 
@@ -1155,7 +1155,7 @@ class TmxPicoAio:
             
             
             command = [PrivateConstants.ENCODER_NEW, encoder_type, pin_A, pin_B]
-            self._send_command(command)
+            await self._send_command(command)
         else:
             if self.shutdown_on_exception:
                 self.shutdown()
@@ -1535,12 +1535,12 @@ class TmxPicoAio:
             await self.report_dispatch[report](packet[1:])
             await asyncio.sleep(self.sleep_tune)
 
-    def set_scan_delay(self, delay):
+    async def set_scan_delay(self, delay):
         """
         Set the scan delay to a delay in ms
         """
         command = [PrivateConstants.SET_SCAN_DELAY, delay]
-        self._send_command(command)
+        await self._send_command(command)
 
 
     async def _analog_message(self, data):

--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -157,6 +157,7 @@ class TmxPicoAio:
 
         self.encoder_callbacks = {}
         self.encoder_count = 0
+        self.encoder_steps = {}
 
         # serial port in use
         self.serial_port = None
@@ -1143,6 +1144,7 @@ class TmxPicoAio:
             raise RuntimeError('set_pin_mode_encoder: quadrature encoder requires pin_B')
         if self.encoder_count < PrivateConstants.MAX_ENCODERS:
             self.encoder_callbacks[pin_A] = callback
+            self.encoder_steps[pin_A] = 0
             self.encoder_count+= 1
             self.pico_pins[pin_A] = PrivateConstants.AT_ENCODER
 
@@ -1457,9 +1459,10 @@ class TmxPicoAio:
         steps = report[1]
         if(steps > 128): # convert from uint8 to int8 value
             steps -= 256
+        self.encoder_steps[report[0]] +=steps
         
         cb_list = [PrivateConstants.ENCODER_REPORT, report[0],
-                    steps, time.time()]
+                    self.encoder_steps[report[0]], time.time()]
 
         cb(cb_list)
 

--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -1720,11 +1720,11 @@ class TmxPicoAio:
         cb = self.sonar_callbacks[report[0]]
 
         # build report data
-        if report[1] == 0 and report[2] == 0:
+        if report[1] == 0 and report[2] == 0 and report[3] == 0:
             cb_list = [PrivateConstants.SONAR_DISTANCE, report[0],
                        0, time.time()]
         else:
             cb_list = [PrivateConstants.SONAR_DISTANCE, report[0],
-                       (report[1] + (report[2] / 100)), time.time()]
+                       (report[1]*100 + report[2] + (report[3] / 100)), time.time()]
 
         await cb(cb_list)

--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -1134,7 +1134,6 @@ class TmxPicoAio:
        ENCODER_REPORT =  14
 
         """
-
         if not callback:
             if self.shutdown_on_exception:
                 self.shutdown()
@@ -1302,7 +1301,6 @@ class TmxPicoAio:
        SONAR_DISTANCE =  11
 
         """
-
         if not callback:
             if self.shutdown_on_exception:
                 await self.shutdown()
@@ -1443,7 +1441,7 @@ class TmxPicoAio:
         except (RuntimeError, SerialException):
             pass
 
-    def _encoder_report(self, report):
+    async def _encoder_report(self, report):
         """
 
         :param report: data[0] = pin A, data[1] = steps (signed)
@@ -1461,7 +1459,7 @@ class TmxPicoAio:
         cb_list = [PrivateConstants.ENCODER_REPORT, report[0],
                     steps, time.time()]
 
-        cb(cb_list)
+        await cb(cb_list)
 
     async def _spi_report(self, report):
         """

--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -620,7 +620,6 @@ class TmxPicoAio:
         for item in args:
             command.append(item)
         await self._send_command(command)
-        await asyncio.sleep(0.1)
 
     async def neo_pixel_set_value(self, pixel_number, r=0, g=0, b=0, auto_show=False):
         """


### PR DESCRIPTION
Add property to allow i2c errors. 
Instead of throwing a RuntimeError, it will print the message and continue.

Used by Mirte Telemetrix for when there is no oled connected, but it is in the configuration.