### PR TITLE
remove mm scale from sonar

### DIFF
--- a/tmx_pico_aio/tmx_pico_aio.py
+++ b/tmx_pico_aio/tmx_pico_aio.py
@@ -1780,6 +1780,6 @@ class TmxPicoAio:
                        0, time.time()]
         else:
             cb_list = [PrivateConstants.SONAR_DISTANCE, report[0],
-                       (report[1]*100 + report[2] + (report[3] / 100)), time.time()]
+                       (report[1]*100 + report[2]), time.time()]
 
         await cb(cb_list)


### PR DESCRIPTION
Sonar is not that accurate, so removed that part of the message. Needs the pull request of the telemetrix4rpipico as well

https://github.com/mirte-robot/Telemetrix4RpiPico/pull/8